### PR TITLE
#3: サマータイムに対応し、price カラムを 0.1 pips 単位で表示できるように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ oanda のオーダーブックを分析するためのコマンドラインツ�
 | losing-position | 損失が出ているポジションの下限比率を指定します。複数指定した場合はその数値が連続した価格帯が存在している箇所を検索します。 |
 | profiting-position | 利益が出ているポジションの下限比率を指定します。複数指定した場合はその数値が連続した価格帯が存在している箇所を検索します。 |
 | jp | Excel 最適化を行います |
-| loc | date-time カラムの time location を指定します。 UTC, JST, MT4 が選択可能です。 |
+| loc | date-time カラムの time location を指定します。 UTC, JST, EST が選択可能です。 |
 
 ex:
+
 ```
 go run . -oanda-key xxxxxxx -period 2020/10/01-2020/10/04 -instrument EUR_GBP -stop-order 0.5-1.0 -jp -loc MT4
-
 ```
 
 ### output

--- a/lib/oanda/price.go
+++ b/lib/oanda/price.go
@@ -11,47 +11,48 @@ type Pips float64 // valid up to the first minority
 
 func (p Pips) PipsToPrice(instrument Instrument) Price {
 	if instrument == InstrumentUSDJPY {
-		return Price(math.Ceil(float64(p))/100)
+		return Price(math.Ceil(float64(p)) / 100)
 	}
 	if instrument == InstrumentEURJPY {
-		return Price(math.Ceil(float64(p))/100)
+		return Price(math.Ceil(float64(p)) / 100)
 	}
 	if instrument == InstrumentAUDJPY {
-		return Price(math.Ceil(float64(p))/100)
+		return Price(math.Ceil(float64(p)) / 100)
 	}
 	if instrument == InstrumentGBPJPY {
-		return Price(math.Ceil(float64(p))/100)
+		return Price(math.Ceil(float64(p)) / 100)
 	}
 	if instrument == InstrumentEURUSD {
-		return Price(math.Ceil(float64(p))/10000)
+		return Price(math.Ceil(float64(p)) / 10000)
 	}
 	if instrument == InstrumentGBPUSD {
-		return Price(math.Ceil(float64(p))/10000)
+		return Price(math.Ceil(float64(p)) / 10000)
 	}
 	if instrument == InstrumentAUDUSD {
-		return Price(math.Ceil(float64(p))/10000)
+		return Price(math.Ceil(float64(p)) / 10000)
 	}
 	if instrument == InstrumentNZDUSD {
-		return Price(math.Ceil(float64(p))/10000)
+		return Price(math.Ceil(float64(p)) / 10000)
 	}
 	if instrument == InstrumentEURGBP {
-		return Price(math.Ceil(float64(p))/10000)
+		return Price(math.Ceil(float64(p)) / 10000)
 	}
 	return 0
 }
 
 func (p Price) Round(instrument Instrument) Price {
-	r := 10/float64(Pips(1).PipsToPrice(instrument))
-	return Price(math.Round(float64(p)*r)/r)
+	r := 10 / float64(Pips(1).PipsToPrice(instrument))
+	return Price(math.Round(float64(p)*r) / r)
 }
 
 func (p Price) RoundFivePips(instrument Instrument) Price {
-	r := float64(Pips(1).PipsToPrice(instrument)*10)
-	return Price(math.Round(float64(p)*2/r)*r/2).Round(instrument)
+	r := float64(Pips(1).PipsToPrice(instrument) * 10)
+	return Price(math.Round(float64(p)*2/r) * r / 2).Round(instrument)
 }
 
+// PriceStr converts string price. (0.1 pips units)
 func (p Price) PriceStr(instrument Instrument) string {
 	r := math.Floor(1 / float64(Pips(1).PipsToPrice(instrument)))
-	rDigits := int(math.Log10(r))
+	rDigits := int(math.Log10(r)) + 1
 	return strconv.FormatFloat(float64(p), 'f', rDigits, 64)
 }

--- a/main.go
+++ b/main.go
@@ -460,14 +460,19 @@ func timeString(t time.Time, loc string) string {
 	if err != nil {
 		log.Fatalf("failed to load time location: %v", err)
 	}
+	est, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		log.Fatalf("failed to load time location: %v", err)
+	}
 	if loc == "UTC" {
 		t = t.In(utc)
 	} else if loc == "JST" {
 		t = t.In(jst)
 	} else if loc == "MT4" {
-		t = t.In(utc)
-		t = t.Add(2 * time.Hour)
+		t = t.In(est)
+		t = t.Add(7 * time.Hour)
 	}
+
 	y, m, d := t.Date()
 	return fmt.Sprintf("%04d/%02d/%02d %02d:%02d:%02d", y, int(m), d, t.Hour(), t.Minute(), t.Second())
 }


### PR DESCRIPTION
## 変更内容
- -loc MT4 オプションを指定した場合に、サマータイムによる時間のズレを修正
- price カラムを 0.1 pips 単位で表示できるように修正

## 備考

oanda の MT4 サーバーは、GMT+2 と GMT+3 をサマータイムで切り替えている。これは EST+7 と同等と考えられるのでこの方法で実装する。[詳細](https://www.leaprate.com/news/oanda-establishes-new-server-for-metatrader-4-clients/#:~:text=OANDA%20establishes%20new%20server%20for%20MetaTrader%204%20clients,-October%2031%2C%202014&text=The%20existing%20OANDA%20MT4%20server,company%20will%20continue%20to%20support.)