### PR TITLE
#5: ExtractBucketVicinityOfPrice() 関数のバグ修正

### DIFF
--- a/lib/oanda/book.go
+++ b/lib/oanda/book.go
@@ -3,6 +3,7 @@ package oanda
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 )
@@ -84,12 +85,13 @@ func (o *Book) ExtractBucket(maxPrice, minPrice float64) {
 }
 
 func (o *Book) ExtractBucketVicinityOfPrice(price Price, n int) (short, long []BookBucket, err error) {
+	sort.Slice(o.Buckets, func(i, j int) bool { return o.Buckets[i].Price < o.Buckets[j].Price })
 	var lowerBuckets []BookBucket
 	var higherBuckets []BookBucket
 	for i, b := range o.Buckets {
 		if b.Price > price {
-			lowerBuckets = o.Buckets[:i-1]
-			higherBuckets = o.Buckets[i-1:]
+			lowerBuckets = o.Buckets[:i]
+			higherBuckets = o.Buckets[i:]
 			break
 		}
 	}

--- a/lib/oanda/book_test.go
+++ b/lib/oanda/book_test.go
@@ -1,0 +1,96 @@
+package oanda
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBook_ExtractBucketVicinityOfPrice(t *testing.T) {
+	type fields struct {
+		Instrument Instrument
+		Price      Price
+		Buckets    []BookBucket
+	}
+	type args struct {
+		price Price
+		n     int
+	}
+	tests := []struct {
+		fields    fields
+		args      args
+		wantShort []BookBucket
+		wantLong  []BookBucket
+		wantErr   bool
+	}{
+		{
+			fields: fields{
+				Instrument: InstrumentUSDJPY,
+				Buckets: []BookBucket{
+					{Price: 99.95},
+					{Price: 100.00},
+					{Price: 100.15},
+					{Price: 100.05},
+					{Price: 99.90},
+					{Price: 100.10},
+					{Price: 99.85},
+					{Price: 100.20},
+				},
+			},
+			args: args{price: 100.001, n: 3},
+			wantShort: []BookBucket{
+				{Price: 100.00},
+				{Price: 99.95},
+				{Price: 99.90},
+			},
+			wantLong: []BookBucket{
+				{Price: 100.05},
+				{Price: 100.10},
+				{Price: 100.15},
+			},
+			wantErr: false,
+		},
+		{
+			fields: fields{
+				Instrument: InstrumentEURGBP,
+				Buckets: []BookBucket{
+					{Price: 0.90600},
+					{Price: 0.90650},
+					{Price: 0.90800},
+					{Price: 0.90550},
+					{Price: 0.90700},
+					{Price: 0.90500},
+					{Price: 0.90750},
+				},
+			},
+			args: args{price: 0.90670, n: 3},
+			wantShort: []BookBucket{
+				{Price: 0.90650},
+				{Price: 0.90600},
+				{Price: 0.90550},
+			},
+			wantLong: []BookBucket{
+				{Price: 0.90700},
+				{Price: 0.90750},
+				{Price: 0.90800},
+			},
+			wantErr: false,
+		},
+	}
+	for i, tt := range tests {
+		o := &Book{
+			Instrument: tt.fields.Instrument,
+			Buckets:    tt.fields.Buckets,
+		}
+		gotShort, gotLong, err := o.ExtractBucketVicinityOfPrice(tt.args.price, tt.args.n)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("#%d ExtractBucketVicinityOfPrice() error = %v, wantErr %v", i, err, tt.wantErr)
+			return
+		}
+		if !reflect.DeepEqual(gotShort, tt.wantShort) {
+			t.Errorf("#%d ExtractBucketVicinityOfPrice() gotShort = %v, want %v", i, gotShort, tt.wantShort)
+		}
+		if !reflect.DeepEqual(gotLong, tt.wantLong) {
+			t.Errorf("#%d ExtractBucketVicinityOfPrice() gotLong = %v, want %v", i, gotLong, tt.wantLong)
+		}
+	}
+}


### PR DESCRIPTION
## 修正内容

ExtractBucketVicinityOfPrice() 関数のテストを追加し、order book の bucket が適切に分類されない問題を修正